### PR TITLE
Revert "Bump softprops/action-gh-release from 2.1.0 to 2.2.0"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,6 @@ jobs:
           subject-path: dist/*
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           files: dist/*


### PR DESCRIPTION
Reverts ludeeus/pyhomely#81